### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,15 +9,15 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.7', '3.9', '3.10']
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -43,14 +43,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.12"
 
       - name: Insert version number
         run: |

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 What is lingva?
 ===============
 
-This is a fork of package of https://github.com/wichert/lingua
+**This is a fork of https://github.com/wichert/lingua**
 
 Lingva is a package with tools to extract translatable texts from
 your code, and to check existing translations. It replaces the use

--- a/src/lingva/extract.py
+++ b/src/lingva/extract.py
@@ -11,10 +11,7 @@ import sys
 import tempfile
 import time
 
-try:
-    from configparser import SafeConfigParser
-except ImportError:
-    from ConfigParser import SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 import click
 import polib
 from lingva.extractors import get_extractor

--- a/src/lingva/extractors/__init__.py
+++ b/src/lingva/extractors/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
-from pkg_resources import DistributionNotFound
-from pkg_resources import working_set
+
+from importlib.metadata import entry_points
+
 import abc
 import collections
 import os
@@ -162,13 +163,8 @@ class Extractor(object):
 
 
 def register_extractors():
-    for entry_point in working_set.iter_entry_points("lingva.extractors"):
-        try:
-            extractor = entry_point.load(require=True)
-        except DistributionNotFound:
-            # skip this entry point since at least one required dependency can
-            # not be found
-            extractor = None
+    for entry_point in entry_points("lingua.extractors"):
+        extractor = entry_point.load()
         if extractor:
             if not issubclass(extractor, Extractor):
                 raise ValueError("Registered extractor must derive from ``Extractor``")

--- a/src/lingva/extractors/babel.py
+++ b/src/lingva/extractors/babel.py
@@ -1,5 +1,5 @@
-from pkg_resources import DistributionNotFound
-from pkg_resources import working_set
+from importlib.metadata import entry_points
+
 from .python import KEYWORDS
 from .python import parse_keyword
 from . import EXTRACTORS
@@ -58,15 +58,10 @@ class BabelExtractor(Extractor):
 
 
 def register_babel_plugins():
-    for entry_point in working_set.iter_entry_points("babel.extractors"):
-        name = entry_point.name
-        try:
-            extractor = entry_point.load(require=True)
-        except DistributionNotFound:
-            # skip this entry point since at least one required dependency can
-            # not be found
-            extractor = None
+    for entry_point in entry_points("babel.extractors"):
+        extractor = entry_point.load()
         if extractor:
+            name = entry_point.name
             cls = type(
                 "BabelExtractor_%s" % name,
                 (BabelExtractor, object),

--- a/tests/extractors/test_python.py
+++ b/tests/extractors/test_python.py
@@ -227,7 +227,7 @@ def test_function_argument():
     options = mock.Mock()
     options.keywords = []
     options.comment_tag = "I18N:"
-    source = u"""_('word', func('foo', 2'))"""
+    source = u"""_('word', func('foo', 2))"""
     messages = list(python_extractor("filename", options))
     assert len(messages) == 1
     assert messages[0].msgid == "word"


### PR DESCRIPTION
  - Use Python 3.8-3.12 for test matrix
  - Bump GH action versions
  - Fix configparser SafeConfigParser name issue (the initial one)
  - Replace pkg_resources with importlib.metadata
  - Fix failing test