### PR TITLE
Add utf-8 encoding for extractors::python::_open

### DIFF
--- a/src/lingva/extractors/python.py
+++ b/src/lingva/extractors/python.py
@@ -105,7 +105,7 @@ def parse_translationstring(arguments, filename, firstline):
 
 def _open(filename):
     """Injection point for tests."""
-    return open(filename, "r")
+    return open(filename, "r", encoding="utf-8")
 
 
 def safe_eval(s):


### PR DESCRIPTION
Fixes 

```
File "G:\python-holidays\env\Lib\site-packages\lingva\extractors\python.py", line 125, in __call__
    line = self.readline()
           ^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2670: character maps to <undefined>
```