### PR TITLE
Fix `--allow-empty` parameter

### DIFF
--- a/src/lingva/extract.py
+++ b/src/lingva/extract.py
@@ -409,7 +409,7 @@ def extract(
     help="Order messages by file location",
 )
 @click.option(
-    "--allow-empty",
+    "--allow-empty/--no-allow-empty",
     "allow_empty",
     default=False,
     help="Allow output file with no msg entries",


### PR DESCRIPTION
Fix `pot-create` script parameter `--allow-empty`.