### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 21
+    directory: /
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    schedule:
+      day: wednesday
+      interval: weekly
+
+  - package-ecosystem: pre-commit
+    cooldown:
+      default-days: 21
+    directory: /
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    schedule:
+      day: wednesday
+      interval: weekly
+
+  - package-ecosystem: uv
+    cooldown:
+      default-days: 21
+    directory: /
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    schedule:
+      day: wednesday
+      interval: weekly


### PR DESCRIPTION
## Summary

Closes #31.

Adds `.github/dependabot.yml` adapted from [vacanza/holidays](https://github.com/vacanza/holidays/blob/dev/.github/dependabot.yml). Keeps the three ecosystems that apply to lingva:

- `github-actions` - the workflow at `.github/workflows/test.yaml` pins actions by SHA
- `pre-commit` - `.pre-commit-config.yaml` is present
- `uv` - migrated in commit `ec39b8b` ("Migrate to uv for dependency management")

## Differences from the source

- Dropped `target-branch: dev` - lingva's default branch is `main`, so dependabot lands there automatically.
- Everything else (cooldown, group, weekly-wednesday schedule) is copied verbatim so dependabot behavior matches holidays.

## Testing

`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly. Dependabot will pick it up on the next scheduled check after merge.